### PR TITLE
Decode WebM audio server-side

### DIFF
--- a/ai_interviewer/audio_processing/speech_to_text.py
+++ b/ai_interviewer/audio_processing/speech_to_text.py
@@ -1,8 +1,17 @@
 # ai_interviewer/audio_processing/speech_to_text.py
 
+"""Utilities for converting speech to text.
+
+The frontend streams audio to the backend as WebM/Opus.  Whisper expects
+16‑kHz mono PCM bytes, so this module is responsible for converting the
+compressed stream into the appropriate raw format before transcription.
+"""
+
 from faster_whisper import WhisperModel
 import numpy as np
 from ai_interviewer.config import STT_MODEL
+from pydub import AudioSegment
+import io
 
 try:
     print(f"Loading STT model: {STT_MODEL}...")
@@ -13,12 +22,27 @@ except Exception as e:
     stt_model = WhisperModel(STT_MODEL, device="cpu", compute_type="int8")
 
 
+def _webm_to_pcm16(audio_bytes: bytes) -> bytes:
+    """Decode WebM/Opus bytes into 16‑bit PCM at 16 kHz.
+
+    Pydub uses ffmpeg under the hood.  The resulting audio is mono with a
+    sample width of 2 bytes, which matches Whisper's expected input format.
+    """
+
+    audio = AudioSegment.from_file(io.BytesIO(audio_bytes), format="webm")
+    audio = audio.set_frame_rate(16000).set_channels(1).set_sample_width(2)
+    return audio.raw_data
+
+
 def transcribe_audio(audio_bytes: bytes) -> str:
-    # ... (function content remains the same)
+    """Transcribe WebM/Opus audio to text using Whisper."""
+
     if not audio_bytes:
         return ""
+
     try:
-        audio_np = np.frombuffer(audio_bytes, dtype=np.int16).astype(np.float32) / 32768.0
+        pcm_bytes = _webm_to_pcm16(audio_bytes)
+        audio_np = np.frombuffer(pcm_bytes, dtype=np.int16).astype(np.float32) / 32768.0
         segments, _ = stt_model.transcribe(audio_np, beam_size=5)
         transcription = " ".join([seg.text.strip() for seg in segments])
         return transcription

--- a/ai_interviewer/frontend/index.html
+++ b/ai_interviewer/frontend/index.html
@@ -70,7 +70,7 @@
         // --- Configuration ---
         const SESSION_ID = `session_${Date.now()}`;
         const WEBSOCKET_URL = `ws://localhost:8000/interview/${SESSION_ID}`; // Assumes FastAPI runs on port 8000
-        const AUDIO_SAMPLE_RATE = 16000; // Sample rate required by Whisper
+        const AUDIO_SAMPLE_RATE = 16000; // Whisper expects 16 kHz; server handles resampling
         const AUDIO_TIMESLICE = 500; // Send audio data every 500ms
 
         // --- State Management ---
@@ -168,12 +168,9 @@
 
                 mediaRecorder.ondataavailable = (event) => {
                     if (event.data.size > 0 && websocket && websocket.readyState === WebSocket.OPEN) {
-                        // This sends audio as a Blob. The backend will need to handle it.
-                        // For raw PCM bytes, a more complex setup with an AudioWorklet is needed.
-                        // This approach is simpler and works if the backend can decode webm/opus.
-                        // **NOTE**: The provided Python backend expects raw PCM bytes. This client
-                        // would need an AudioWorklet to convert the stream to the correct format.
-                        // For this test, we'll assume the backend can be adapted or this is a demo.
+                        // Audio is sent as WebM/Opus blobs. The backend decodes and resamples
+                        // to 16‑kHz mono PCM using ffmpeg/pydub before transcription, so an
+                        // AudioWorklet is not required here.
                         websocket.send(event.data);
                     }
                 };

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,4 +8,5 @@ dependencies = [
     "fastapi>=0.116.1",
     "pydantic>=2.11.7",
     "uvicorn>=0.35.0",
+    "pydub>=0.25.1",
 ]


### PR DESCRIPTION
## Summary
- Decode incoming WebM/Opus audio to 16 kHz PCM using pydub before transcription
- Clarify that frontend streams WebM and server performs decoding; add pydub dependency

## Testing
- `pip install pydub` *(failed: Could not find a version that satisfies the requirement pydub)*
- `apt-get update` *(failed: repository ... 403 Forbidden)*
- `python -m py_compile ai_interviewer/audio_processing/speech_to_text.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab2199b06c8328a7627f9d8aa42561